### PR TITLE
kill process group to avoid generate orphan process

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -34,12 +34,19 @@ func CmdOutNoLn(name string, arg ...string) (out string, err error) {
 }
 
 func CmdRunWithTimeout(cmd *exec.Cmd, timeout time.Duration) (error, bool) {
+	var err error
+
+	//set group id
+	err = syscall.Setpgid(cmd.Process.Pid, cmd.Process.Pid)
+	if err != nil {
+		log.Println("Setpgid failed, error:", err)
+	}
+
 	done := make(chan error)
 	go func() {
 		done <- cmd.Wait()
 	}()
 
-	var err error
 	select {
 	case <-time.After(timeout):
 		log.Printf("timeout, process:%s will be killed", cmd.Path)
@@ -48,11 +55,15 @@ func CmdRunWithTimeout(cmd *exec.Cmd, timeout time.Duration) (error, bool) {
 			<-done // allow goroutine to exit
 		}()
 
-		// timeout
-		if err = cmd.Process.Kill(); err != nil {
-			log.Printf("failed to kill: %s, error: %s", cmd.Path, err)
+		err = syscall.Kill(cmd.Process.Pid-(cmd.Process.Pid*2), 9)
+		if err != nil {
+			log.Println("kill plugin failed, error:", err)
 		}
-
+		/*
+			if err = cmd.Process.Kill(); err != nil {
+				log.Printf("failed to kill: %s, error: %s", cmd.Path, err)
+			}
+		*/
 		return err, true
 	case err = <-done:
 		return err, false


### PR DESCRIPTION
The method CmdRunWithTimeout() will occur a bug when the command like 'su -c "/xxx/main.py" root'.
If the command include a script to run and this script is a blocking script like "while True:pass", the script will occur timeout. The method will kill the process when the script execute timeout. But it only kill the parent process, the child process will be a orphan process, for example the main.py process. When the method be called very frequently, it will generate many orphan process and finally run out of system resources. So when timeout event occurd, it should kill the all process group not only a parent process.