### PR TITLE
syscall.Kill not supported on windows

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package sys
 
 import (


### PR DESCRIPTION
If compile on windows, it will return

```
github.com\toolkits\sys\cmd.go:54:9: undefined: syscall.Kill
```

So add `build linux` in the file.